### PR TITLE
Tweaks to the s3fs-recipe for storing of credentials & mounting options

### DIFF
--- a/s3fs/attributes/default.rb
+++ b/s3fs/attributes/default.rb
@@ -1,2 +1,3 @@
 default["fuse"]["version"] = "2.8.7"
 default["s3fs"]["version"] = "1.61"
+default["s3fs"]["options"] = 'allow_other,use_cache=/tmp'

--- a/s3fs/templates/default/passwd-s3fs.erb
+++ b/s3fs/templates/default/passwd-s3fs.erb
@@ -1,0 +1,1 @@
+<%= @access_key %>:<%= @secret_key %>


### PR DESCRIPTION
I have done some modifications to the s3fs recipe based on my uses that I thought you might want to put back into your master.
- Modified the credentials use to store within a s3passwd file as per s3 fuse documentation
- Added in mounting options as an attribute for further flexibiliy
- Miscellaneous tidy ups to create and mount using chef commands
