### PR TITLE
Allow mounting multiple buckets across multiple AWS IAM Users

### DIFF
--- a/s3fs/attributes/default.rb
+++ b/s3fs/attributes/default.rb
@@ -12,6 +12,9 @@ when "debian", "ubuntu"
   default["s3fs"]["packages"] = %w{build-essential pkg-config libcurl4-openssl-dev libfuse-dev fuse-utils libfuse2 libxml2-dev mime-support}
   default["fuse"]["version"] = "2.8.7"
 end
+
+default["s3fs"]["mount_root"] = '/mnt'
+default["s3fs"]["multi_user"] = false
 default["s3fs"]["version"] = "1.69"
 default["s3fs"]["options"] = 'allow_other,use_cache=/tmp'
 

--- a/s3fs/readme.md
+++ b/s3fs/readme.md
@@ -32,6 +32,10 @@ It will install s3fs on your server, then it will create folders in the /mnt dir
 
 The recipe will handle encrypted data bags, and uses the Chef::EncryptedDataBagItem.load with default decryption key file.
 
+## Multi User Support
+
+If you have multiple AWS IAM users with different keys and multiple buckets that need mounted, you can use `node['s3fs']['multi_user']`. By setting this attribute to true, it will allow you to mount multiple buckets across as many user accounts (with different keys) as you want. Instead of using `node["s3fs"]["data_bag"]["item"]` to specify which data bag item to load, you create one or more data bags under `node["s3fs"]["data_bag"]["name"]` for each unique AWS IAM user you need to use. The data bag format is still the same as it always has been.
+
 ## Support
 
 If you have any problems or change requests to this recipe create an issue or submit a pull request on https://github.com/twilson63/s3fs-recipe

--- a/s3fs/templates/default/passwd-s3fs.erb
+++ b/s3fs/templates/default/passwd-s3fs.erb
@@ -1,1 +1,3 @@
-<%= @s3_bag["access_key_id"] %>:<%= @s3_bag["secret_access_key"] %>
+<% @buckets.each do |bucket| %>
+<%= bucket[:name] %>:<%= bucket[:access_key] %>:<%= bucket[:secret_key] %>
+<% end %>


### PR DESCRIPTION
Thanks for submitting this cookbook into the community. I had a use case that was not supported and wanted to add support while keeping everything backwards compatible. I noticed a few things while doing this.
1. It seems the next logical thing to do would be to extend the mount LWRP and create a s3fs_mount LWRP. That way, you could hook into this cookbook with other custom use cases in other cookbooks.
2. I wasn't sure where to place the retrieve_s3_buckets method. The recipe file doesn't seem like a good place but I do not know where it _should_ go.
3. The mount root of /mnt was hard coded so I made it a configurable attribute.

Thanks!

Jesse
