### PR TITLE
Make sure the filesystem shows up in fstab.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -134,7 +134,7 @@ buckets.each do |bucket|
     options node['s3fs']['options']
     dump 0
     pass 0
-    action [:mount, :enable]
+    action [:enable, :mount]
     not_if "grep -qs '#{bucket[:path]} ' /proc/mounts"
   end
 end


### PR DESCRIPTION
If we do the mount first thenit looks like the not_if causes
the enable step to be skipped. And the not_if step is needed
since chef (10.18.2) fails to detect if the filesystem is mounted.
