### PR TITLE
Support Ubuntu 14.04.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,6 +13,10 @@ when "amazon"
 when "debian", "ubuntu"
   default["s3fs"]["packages"] = %w{build-essential pkg-config libcurl4-openssl-dev libfuse-dev fuse-utils libfuse2 libxml2-dev mime-support}
   default["fuse"]["version"] = "2.8.7"
+  case node["platform_version"].to_i
+  when 14.04
+    default["s3fs"]["packages"] = %w{build-essential pkg-config libcurl4-openssl-dev libfuse-dev fuse-emulator-utils libfuse2 libxml2-dev mime-support}
+  end
 end
 
 default["s3fs"]["mount_root"] = '/mnt'


### PR DESCRIPTION
There is no fuse-utils package for Ubuntu 14.04.  But fuse-emulator-utils can
be used in stead.
