### PR TITLE
OpenSUSE 13.1 support + Encrypted Data Bag

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,12 @@
+default["s3fs"]["build_from_source"] = true
+
 case node["platform"]
+when "opensuse"
+  case node["platform_version"].to_f
+  when 13.1
+  	default["s3fs"]["packages"] = %w{s3fs} #available in package manager on opensuse 13.1 and fuse is already install 
+  end
+  default["fuse"]["version"] = "2.9.3"
 when "centos", "redhat"
   default["s3fs"]["packages"] = %w{gcc libstdc++-devel gcc-c++ curl-devel libxml2-devel openssl-devel mailcap make}
   case node["platform_version"].to_i

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,7 +33,5 @@ default["s3fs"]["version"] = "1.69"
 default["s3fs"]["options"] = 'allow_other,use_cache=/tmp'
 
 default["s3fs"]["data"] = {
-  "buckets" => [],
-  "access_key_id" => "",
-  "secret_access_key" => "",
+  "buckets" => []
 }

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -91,8 +91,8 @@ def retrieve_s3_buckets(s3_data)
     buckets << {
       :name => bucket.name,
       :path => bucket.path,
-      :access_key => s3_data['access_key_id'],
-      :secret_key => s3_data['secret_access_key']
+      :access_key => '',
+      :secret_key => ''
     }
   end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,6 +21,8 @@ node['s3fs']['packages'].each do |pkg|
   package pkg
 end
 
+if node['s3fs']['build_from_source'] == true
+
 if not node['s3fs']['packages'].include?("fuse")
   # install fuse
   remote_file "#{Chef::Config[:file_cache_path]}/fuse-#{ node['fuse']['version'] }.tar.gz" do
@@ -77,6 +79,9 @@ bash "install s3fs" do
 
   not_if { File.exists?("/usr/bin/s3fs") }
 end
+
+end
+
 
 def retrieve_s3_buckets(s3_data)
   buckets = []

--- a/templates/default/passwd-s3fs.erb
+++ b/templates/default/passwd-s3fs.erb
@@ -1,3 +1,3 @@
 <% @buckets.each do |bucket| %>
-<%= bucket[:name] %>:<%= bucket[:access_key] %>:<%= bucket[:secret_key] %>
+<%= bucket[:name] %>:<%= Chef::EncryptedDataBagItem.load("aws_users", "s3_user")["aws_access_key"] %>:<%= Chef::EncryptedDataBagItem.load("aws_users", "s3_user")["aws_secret_key"] %>
 <% end %>


### PR DESCRIPTION
OpenSUSE support:
Install s3fs using system package manager in OpenSUSE. Added option to build_from_source, for compatibility with other distros. 

Encrypted data bags: 
Instead of expecting the credentials to be passed as attributes (meaning they would have to be stored as plain text in some other source control repo), I've added support for accepting the credentials through an encrypted data bag. 
