### PR TITLE
Switch action order to [:mount, :enable].

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -151,7 +151,7 @@ buckets.each do |bucket|
     options node['s3fs']['options']
     dump 0
     pass 0
-    action [:enable, :mount]
+    action [:mount, :enable]
     not_if "grep -qs '#{bucket[:path]} ' /proc/mounts"
   end
 end


### PR DESCRIPTION
According to the docs, it's safer to first mount the drive prior to attempting to enable it:

"Order matters when passing multiple actions. For example: action [:mount, :enable] ensures that the file system
is mounted before it is enabled." -- https://docs.chef.io/resource_mount.html