### PR TITLE
Use new s3fs repo & fixes data_from_bag option

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,6 @@ See `attributes/default.rb` for defaults generated per platform.
 * `node["s3fs"]["mount_root"]` - The root path for any mounted S3 buckets
 * `node["s3fs"]["multi_user"]` - Enable multi-user support
 * `node["s3fs"]["options"]` - Options to set when mounting a bucket to the filesystem
-* `node["s3fs"]["data_bag"]["name"]` - The name of the data bag that contains an item with the buckets to mount & necessary AWS credentials
-* `node["s3fs"]["data_bag"]["item"]` - The name of the data bag item that contains the buckets to mount & necessary AWS credentials
 
 # Recipes
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,12 @@
+default["s3fs"]["build_from_source"] = true
+
 case node["platform"]
+when "opensuse"
+  case node["platform_version"].to_f
+  when 13.1
+  	default["s3fs"]["packages"] = %w{s3fs} #available in package manager on opensuse 13.1 and fuse is already install 
+  end
+  default["fuse"]["version"] = "2.9.3"
 when "centos", "redhat"
   default["s3fs"]["packages"] = %w{gcc libstdc++-devel gcc-c++ curl-devel libxml2-devel openssl-devel mailcap make}
   case node["platform_version"].to_i
@@ -25,7 +33,5 @@ default["s3fs"]["version"] = "1.69"
 default["s3fs"]["options"] = 'allow_other,use_cache=/tmp'
 
 default["s3fs"]["data"] = {
-  "buckets" => [],
-  "access_key_id" => "",
-  "secret_access_key" => "",
+  "buckets" => []
 }

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,7 +29,7 @@ end
 
 default["s3fs"]["mount_root"] = '/mnt'
 default["s3fs"]["multi_user"] = false
-default["s3fs"]["version"] = "v1.79"
+default["s3fs"]["version"] = "1.79"
 default["s3fs"]["options"] = 'allow_other,use_cache=/tmp'
 
 default["s3fs"]["data_from_bag"] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,7 +29,7 @@ end
 
 default["s3fs"]["mount_root"] = '/mnt'
 default["s3fs"]["multi_user"] = false
-default["s3fs"]["version"] = "1.69"
+default["s3fs"]["version"] = "v1.79"
 default["s3fs"]["options"] = 'allow_other,use_cache=/tmp'
 
 default["s3fs"]["data_from_bag"] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,7 +14,7 @@ when "debian", "ubuntu"
   default["s3fs"]["packages"] = %w{build-essential pkg-config libcurl4-openssl-dev libfuse-dev fuse-utils libfuse2 libxml2-dev mime-support}
   default["fuse"]["version"] = "2.8.7"
   case node["platform_version"].to_i
-  when 14.04
+  when 14
     default["s3fs"]["packages"] = %w{build-essential pkg-config libcurl4-openssl-dev libfuse-dev fuse-emulator-utils libfuse2 libxml2-dev mime-support}
   end
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,6 +32,8 @@ default["s3fs"]["multi_user"] = false
 default["s3fs"]["version"] = "1.69"
 default["s3fs"]["options"] = 'allow_other,use_cache=/tmp'
 
+default["s3fs"]["data_from_bag"] = false
+
 default["s3fs"]["data"] = {
   "buckets" => []
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'team@jackrussellsoftware.com'
 license          'Apache 2.0'
 description      'Mount one or more S3 buckets to the filesystem.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.0.1'
+version          '2.0.2'
 
 recipe           's3fs', 'Installs and configures S3FS and mounts buckets'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'team@jackrussellsoftware.com'
 license          'Apache 2.0'
 description      'Mount one or more S3 buckets to the filesystem.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.0.2'
+version          '2.0.3'
 
 recipe           's3fs', 'Installs and configures S3FS and mounts buckets'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'team@jackrussellsoftware.com'
 license          'Apache 2.0'
 description      'Mount one or more S3 buckets to the filesystem.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.0.4'
+version          '3.0.0'
 
 recipe           's3fs', 'Installs and configures S3FS and mounts buckets'
 
@@ -25,8 +25,8 @@ attribute 's3fs/packages',
 
 attribute 's3fs/version',
   :display_name => 's3fs version',
-  :description => 'Version of s3fs to install',
-  :default => '1.69'
+  :description => 'Version of s3fs to install (github version tag)',
+  :default => 'v1.79'
 
 attribute 's3fs/options',
   :display_name => 'S3FS options',

--- a/metadata.rb
+++ b/metadata.rb
@@ -25,8 +25,8 @@ attribute 's3fs/packages',
 
 attribute 's3fs/version',
   :display_name => 's3fs version',
-  :description => 'Version of s3fs to install (github version tag)',
-  :default => 'v1.79'
+  :description => 'Version of s3fs to install (github release version)',
+  :default => '1.79'
 
 attribute 's3fs/options',
   :display_name => 'S3FS options',

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'team@jackrussellsoftware.com'
 license          'Apache 2.0'
 description      'Mount one or more S3 buckets to the filesystem.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.0.3'
+version          '2.0.4'
 
 recipe           's3fs', 'Installs and configures S3FS and mounts buckets'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -91,8 +91,8 @@ def retrieve_s3_buckets(s3_data)
     buckets << {
       :name => bucket.name,
       :path => bucket.path,
-      :access_key => ((s3_data.includes?(:access_key_id)) ? s3_data['access_key_id'] : ''),
-      :secret_key => ((s3_data.includes?(:secret_access_key)) ? s3_data['secret_access_key'] : '')
+      :access_key => ((s3_data.include?(:access_key_id)) ? s3_data['access_key_id'] : ''),
+      :secret_key => ((s3_data.include?(:secret_access_key)) ? s3_data['secret_access_key'] : '')
     }
   end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -61,7 +61,7 @@ if %w{centos redhat amazon}.include?(node['platform'])
 end
 
 remote_file "#{Chef::Config[:file_cache_path]}/s3fs-#{ node['s3fs']['version'] }.tar.gz" do
-  source "http://s3fs.googlecode.com/files/s3fs-#{ node['s3fs']['version'] }.tar.gz"
+  source "https://github.com/s3fs-fuse/s3fs-fuse/archive/#{ node['s3fs']['version'] }.tar.gz"
   mode 0644
   action :create_if_missing
 end
@@ -78,6 +78,8 @@ bash "install s3fs" do
   "
 
   not_if { File.exists?("/usr/bin/s3fs") }
+end
+
 end
 
 def retrieve_s3_buckets(s3_data)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -60,8 +60,8 @@ if %w{centos redhat amazon}.include?(node['platform'])
   end
 end
 
-remote_file "#{Chef::Config[:file_cache_path]}/s3fs-#{ node['s3fs']['version'] }.tar.gz" do
-  source "https://github.com/s3fs-fuse/s3fs-fuse/archive/#{ node['s3fs']['version'] }.tar.gz"
+remote_file "#{Chef::Config[:file_cache_path]}/s3fs-fuse-#{ node['s3fs']['version'] }.tar.gz" do
+  source "https://github.com/s3fs-fuse/s3fs-fuse/archive/v#{ node['s3fs']['version'] }.tar.gz"
   mode 0644
   action :create_if_missing
 end
@@ -70,8 +70,8 @@ bash "install s3fs" do
   cwd Chef::Config[:file_cache_path]
   code "
     export PKG_CONFIG_PATH=/usr/lib/pkgconfig:/usr/lib64/pkgconfig
-    tar zxvf s3fs-#{ node['s3fs']['version'] }.tar.gz
-    cd s3fs-#{ node['s3fs']['version'] }
+    tar zxvf s3fs-fuse-#{ node['s3fs']['version'] }.tar.gz
+    cd s3fs-fuse-#{ node['s3fs']['version'] }
     ./autogen.sh
     ./configure --prefix=/usr
     make

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,6 +21,8 @@ node['s3fs']['packages'].each do |pkg|
   package pkg
 end
 
+if node['s3fs']['build_from_source'] == true
+
 if not node['s3fs']['packages'].include?("fuse")
   # install fuse
   remote_file "#{Chef::Config[:file_cache_path]}/fuse-#{ node['fuse']['version'] }.tar.gz" do
@@ -78,6 +80,9 @@ bash "install s3fs" do
   not_if { File.exists?("/usr/bin/s3fs") }
 end
 
+end
+
+
 def retrieve_s3_buckets(s3_data)
   buckets = []
 
@@ -86,8 +91,8 @@ def retrieve_s3_buckets(s3_data)
     buckets << {
       :name => bucket.name,
       :path => bucket.path,
-      :access_key => s3_data['access_key_id'],
-      :secret_key => s3_data['secret_access_key']
+      :access_key => '',
+      :secret_key => ''
     }
   end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -91,8 +91,8 @@ def retrieve_s3_buckets(s3_data)
     buckets << {
       :name => bucket.name,
       :path => bucket.path,
-      :access_key => ((s3_data.include?(:access_key_id)) ? s3_data['access_key_id'] : ''),
-      :secret_key => ((s3_data.include?(:secret_access_key)) ? s3_data['secret_access_key'] : '')
+      :access_key => ((s3_data.include?('access_key_id')) ? s3_data['access_key_id'] : ''),
+      :secret_key => ((s3_data.include?('secret_access_key')) ? s3_data['secret_access_key'] : '')
     }
   end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -151,7 +151,7 @@ buckets.each do |bucket|
     options node['s3fs']['options']
     dump 0
     pass 0
-    action [:enable, :mount]
+    action [:mount, :enable]
     not_if "grep -qs '#{bucket[:path]} ' /proc/mounts"
   end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -82,15 +82,34 @@ def retrieve_s3_buckets(s3_data)
   buckets = []
 
   s3_data['buckets'].each do |bucket|
+    bucket = Bucket.new(bucket, node)
     buckets << {
-      :name => bucket,
-      :path => File.join(node['s3fs']['mount_root'], bucket),
+      :name => bucket.name,
+      :path => bucket.path,
       :access_key => s3_data['access_key_id'],
       :secret_key => s3_data['secret_access_key']
     }
   end
 
   buckets
+end
+
+class Bucket
+  attr_reader :name
+  attr_reader :path
+
+  def initialize bucket, node
+    if bucket.is_a? String
+      @name = bucket
+      @path = File.join(node['s3fs']['mount_root'], @name)
+    elsif bucket.is_a? Hash
+      @name = bucket['name']
+      @path = bucket['path']
+    else
+      @name = ""
+      @path = ""
+    end
+  end
 end
 
 if node['s3fs']['multi_user']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -72,6 +72,7 @@ bash "install s3fs" do
     export PKG_CONFIG_PATH=/usr/lib/pkgconfig:/usr/lib64/pkgconfig
     tar zxvf s3fs-#{ node['s3fs']['version'] }.tar.gz
     cd s3fs-#{ node['s3fs']['version'] }
+    ./autogen.sh
     ./configure --prefix=/usr
     make
     make install

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -91,8 +91,8 @@ def retrieve_s3_buckets(s3_data)
     buckets << {
       :name => bucket.name,
       :path => bucket.path,
-      :access_key => '',
-      :secret_key => ''
+      :access_key => ((s3_data.includes?(:access_key_id)) ? s3_data['access_key_id'] : ''),
+      :secret_key => ((s3_data.includes?(:secret_access_key)) ? s3_data['secret_access_key'] : '')
     }
   end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -31,14 +31,13 @@ if not node['s3fs']['packages'].include?("fuse")
 
   bash "install fuse" do
     cwd Chef::Config[:file_cache_path]
-    code <<-EOH
-    tar zxvf fuse-#{ node['fuse']['version'] }.tar.gz
-    cd fuse-#{ node['fuse']['version'] }
-    ./configure --prefix=/usr
-    make
-    make install
-
-    EOH
+    code "
+      tar zxvf fuse-#{ node['fuse']['version'] }.tar.gz
+      cd fuse-#{ node['fuse']['version'] }
+      ./configure --prefix=/usr
+      make
+      make install
+    "
 
     not_if { File.exists?("/usr/bin/fusermount") }
   end
@@ -67,14 +66,14 @@ end
 
 bash "install s3fs" do
   cwd Chef::Config[:file_cache_path]
-  code <<-EOH
-  export PKG_CONFIG_PATH=/usr/lib/pkgconfig:/usr/lib64/pkgconfig
-  tar zxvf s3fs-#{ node['s3fs']['version'] }.tar.gz
-  cd s3fs-#{ node['s3fs']['version'] }
-  ./configure --prefix=/usr
-  make
-  make install
-  EOH
+  code "
+    export PKG_CONFIG_PATH=/usr/lib/pkgconfig:/usr/lib64/pkgconfig
+    tar zxvf s3fs-#{ node['s3fs']['version'] }.tar.gz
+    cd s3fs-#{ node['s3fs']['version'] }
+    ./configure --prefix=/usr
+    make
+    make install
+  "
 
   not_if { File.exists?("/usr/bin/s3fs") }
 end

--- a/templates/default/passwd-s3fs.erb
+++ b/templates/default/passwd-s3fs.erb
@@ -1,3 +1,3 @@
 <% @buckets.each do |bucket| %>
-<%= bucket[:name] %>:<%= bucket[:access_key] %>:<%= bucket[:secret_key] %>
+<%= bucket[:name] %>:<%= Chef::EncryptedDataBagItem.load("aws_users", "s3_user")["aws_access_key"] %>:<%= Chef::EncryptedDataBagItem.load("aws_users", "s3_user")["aws_secret_key"] %>
 <% end %>

--- a/templates/default/passwd-s3fs.erb
+++ b/templates/default/passwd-s3fs.erb
@@ -1,3 +1,3 @@
 <% @buckets.each do |bucket| %>
-<%= bucket[:name] %>:<%= Chef::EncryptedDataBagItem.load("aws_users", "s3_user")["aws_access_key"] %>:<%= Chef::EncryptedDataBagItem.load("aws_users", "s3_user")["aws_secret_key"] %>
+<%= bucket[:name] %>:<%= ( bucket[:access_key] == '' ? Chef::EncryptedDataBagItem.load("aws_users", "s3_user")["aws_access_key"] : bucket[:access_key] ) %>:<%= ( bucket[:secret_key] == '' ? Chef::EncryptedDataBagItem.load("aws_users", "s3_user")["aws_secret_key"] : bucket[:secret_key] ) %>
 <% end %>


### PR DESCRIPTION
You can use all AWS regions in the new s3fs version because it supports AWS Api in Version 4.