### PR TITLE
Add automake to dependency of ubuntu14

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,7 +23,7 @@ when "debian", "ubuntu"
   default["fuse"]["version"] = "2.8.7"
   case node["platform_version"].to_i
   when 14
-    default["s3fs"]["packages"] = %w{build-essential pkg-config libcurl4-openssl-dev libfuse-dev fuse-emulator-utils libfuse2 libxml2-dev mime-support}
+    default["s3fs"]["packages"] = %w{build-essential pkg-config libcurl4-openssl-dev libfuse-dev fuse-emulator-utils libfuse2 libxml2-dev mime-support automake}
     default["fuse"]["version"] = "2.9.5"
   end
 end


### PR DESCRIPTION
on Ubuntu 14.04, we need `automake` to build s3fs.

```
       STDERR: ./autogen.sh: 22: ./autogen.sh: aclocal: not found
       /tmp/chef-script20160517-1817-w4mi2v: line 6: ./configure: No such file or directory
       make: *** No targets specified and no makefile found.  Stop.
       make: *** No rule to make target `install'.  Stop.
       ---- End output of "bash"  "/tmp/chef-script20160517-1817-w4mi2v" ----
       Ran "bash"  "/tmp/chef-script20160517-1817-w4mi2v" returned 2
       [2016-05-17T12:55:55+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
```