### PR TITLE
add skip_passwd option

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -41,3 +41,4 @@ default["s3fs"]["data"] = {
 
 default["s3fs"]["fuse"]["uri"] = 'https://github.com/libfuse/libfuse/releases/download/'
 default["s3fs"]["uri"] = 'https://github.com/s3fs-fuse/s3fs-fuse/archive/'
+default["s3fs"]["skip_passwd"] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,7 +23,7 @@ when "debian", "ubuntu"
   default["fuse"]["version"] = "2.8.7"
   case node["platform_version"].to_i
   when 14
-    default["s3fs"]["packages"] = %w{build-essential pkg-config libcurl4-openssl-dev libfuse-dev fuse-emulator-utils libfuse2 libxml2-dev mime-support}
+    default["s3fs"]["packages"] = %w{build-essential pkg-config libcurl4-openssl-dev libfuse-dev fuse-emulator-utils libfuse2 libxml2-dev mime-support automake}
     default["fuse"]["version"] = "2.9.5"
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'team@jackrussellsoftware.com'
 license          'Apache 2.0'
 description      'Mount one or more S3 buckets to the filesystem.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.0.2'
+version          '3.0.3'
 
 recipe           's3fs', 'Installs and configures S3FS and mounts buckets'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -138,12 +138,14 @@ else
   buckets = retrieve_s3_buckets(node['s3fs']['data'])
 end
 
-template "/etc/passwd-s3fs" do
-  source "passwd-s3fs.erb"
-  owner "root"
-  group "root"
-  mode 0600
-  variables(:buckets => buckets)
+unless node['s3fs']['skip_passwd']
+  template "/etc/passwd-s3fs" do
+    source "passwd-s3fs.erb"
+    owner "root"
+    group "root"
+    mode 0600
+    variables(:buckets => buckets)
+  end
 end
 
 buckets.each do |bucket|


### PR DESCRIPTION
In some case, generating `/etc/passwd-s3fs` is not necessary; especially when we use IAM-Role.
