### PR TITLE
fixing packages for ubuntu 16

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,6 +35,8 @@ when 'debian', 'ubuntu'
       automake
     )
     default['fuse']['version'] = '2.9.5'
+  when 16
+    default['s3fs']['packages'] = %w(build-essential pkg-config libcurl4-openssl-dev libfuse-dev libfuse2 libxml2-dev mime-support automake libssl-dev)
   end
 end
 


### PR DESCRIPTION
Hi, 

I ran into errors with installing the dependencies on ubuntu on 16.04.
* there is no `fuse-utils` package (and looks like we dont need it to compile, so its ok). 
* we need `automake` or s3fs install will fail with
* And i think we need to add `libssl-dev` , as otherwise, the installation will fail with 
```
configure: error: Package requirements (fuse >= 2.8.4 libcurl >= 7.0 libxml-2.0 >= 2.6 libcrypto >= 0.9) were not met:
 
No package 'libcrypto' found
```

Tested via:
```bash
docker run --rm -ti ubuntu:16.04 /bin/bash -c "apt-get update && apt-get -y install build-essential pkg-config libcurl4-openssl-dev libfuse-dev libfuse2 libxml2-dev mime-support automake libssl-dev wget && cd /tmp/ &&  wget https://github.com/s3fs-fuse/s3fs-fuse/archive/v1.79.tar.gz && ls -la &&  tar xzf v1.79.tar.gz && ls -la && cd s3fs-fuse-1.79 && ./autogen.sh && ./configure"
```